### PR TITLE
fix config

### DIFF
--- a/package/config/config.ini
+++ b/package/config/config.ini
@@ -1,5 +1,8 @@
 ######### General Settings ########
 #
+# This is a TF2 lag bot prevention fix that prevents causing rcbots to crash
+sv_quota_stringcmdspersecond 99999
+#
 # General difficulty of the bots. 0.5 = stock, < 0.5 easier, > 0.5 = harder -Broken!
 # Not used - DNA.styx
 # rcbot_skill 0.8
@@ -201,10 +204,6 @@ rcbot_bot_quota_interval -1
 # Or use these settings (but dont use them together with the above setting!)
 rcbotd config min_bots -1
 rcbotd config max_bots 10
-#
-# This is a TF2 lag bot prevention fix that prevents causing rcbots to crash
-sv_quota_stringcmdspersecond 99999
-#
 # These plugins conflict and may not work well with RCBot2. Please inform us for any plugins that
 # conflicts or prevents RCBot2 from working in rcbot.bots-united.com
 # The plugins that have been commented are considered greylisted as they aren't guaranteed to work						 


### PR DESCRIPTION
sv_quota_stringcmdspersecond is in the wrong place.
this can cause RCBots to crash, which can cause the **ENTIRE** server to crash. (i've witnessed this first-hand, this slight edit to the default config is the only real way to fix this issue)